### PR TITLE
fix: output index type i128 to u32

### DIFF
--- a/src/api/endpoints/addresses.rs
+++ b/src/api/endpoints/addresses.rs
@@ -56,7 +56,7 @@ pub struct AddressUtxo {
     /// Transaction hash of the UTXO.
     pub tx_hash: String,
     /// UTXO index in the transaction.
-    pub output_index: Integer,
+    pub output_index: u32,
     /// Sum of assets for this UTXO.
     pub amount: Vec<Amount>,
     /// Block number of the UTXO.


### PR DESCRIPTION
The output index transaction in Cardano is `u32` not `i128`.
Reference to the Transaction Binary Format:
https://github.com/input-output-hk/cardano-sl/blob/develop/docs/tx/binary-format.md#transaction-inputs