### PR TITLE
Allow separate IPFS and Cardano configurations

### DIFF
--- a/src/load.rs
+++ b/src/load.rs
@@ -112,7 +112,6 @@ const NETWORKS: [&str; 2] = ["cardano", "ipfs"];
 ///        _ => None,
 ///    }
 ///}
-///
 /// ```
 pub fn configurations_from_env() -> crate::Result<TomlValue> {
     let config_file = scan_directories_for_config_file()?;


### PR DESCRIPTION
This builds on my previous [PR](https://github.com/blockfrost/blockfrost-rust/pull/25) and I'm not sure you want it or want it implemented this way (which is why I created a separate PR), but this allows a user to configure a project id for both IPFS and Cardano if they want. I had a case where I needed to use both in a single code base and this makes it nice to be able to still use the `load::configurations_from_env` function. I also updated the docs with details on how to use it.