### PR TITLE
Add support for Cardano preview net

### DIFF
--- a/examples/switch_networks.rs
+++ b/examples/switch_networks.rs
@@ -1,0 +1,17 @@
+use blockfrost::{load, BlockFrostApi};
+
+fn build_api() -> blockfrost::Result<BlockFrostApi> {
+    let configurations = load::configurations_from_env()?;
+    let project_id = configurations["project_id"].as_str().unwrap();
+    let api = BlockFrostApi::new(project_id, Default::default());
+    Ok(api)
+}
+
+#[tokio::main]
+async fn main() -> blockfrost::Result<()> {
+    let mut api = build_api()?;
+    api.settings = api.settings.use_previewnet();
+    let genesis = api.genesis().await?;
+    println!("{:#?}", genesis);
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ pub mod stream {
 
 /// The URL of the [BlockFrost API](https://docs.blockfrost.io) for the Cardano mainnet.
 pub const CARDANO_MAINNET_NETWORK: &str = "https://cardano-mainnet.blockfrost.io/api/v0";
+/// The URL of the [BlockFrost API](https://docs.blockfrost.io) for the Cardano preview net.
+pub const CARDANO_PREVIEWNET_NETWORK: &str = "https://cardano-preview.blockfrost.io/api/v0";
 /// The URL of the [BlockFrost API](https://docs.blockfrost.io) for the Cardano testnet.
 pub const CARDANO_TESTNET_NETWORK: &str = "https://cardano-testnet.blockfrost.io/api/v0";
 /// The URL of the BlockFrost IPFS network.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,8 @@
 use std::{fmt, time::Duration};
 
-use crate::{CARDANO_MAINNET_NETWORK, CARDANO_TESTNET_NETWORK, IPFS_NETWORK};
+use crate::{
+    CARDANO_MAINNET_NETWORK, CARDANO_PREVIEWNET_NETWORK, CARDANO_TESTNET_NETWORK, IPFS_NETWORK,
+};
 
 /// Customizable settings for requests made with [`BlockFrostApi`](crate::BlockFrostApi).
 #[derive(Debug, Clone)]
@@ -35,6 +37,12 @@ impl BlockFrostSettings {
     /// Change network to [`CARDANO_TESTNET_NETWORK`].
     pub fn use_testnet(mut self) -> Self {
         self.network_address = CARDANO_TESTNET_NETWORK.to_owned();
+        self
+    }
+
+    /// Change network to [`CARDANO_PREVIEWNET_NETWORK`].
+    pub fn use_previewnet(mut self) -> Self {
+        self.network_address = CARDANO_PREVIEWNET_NETWORK.to_owned();
         self
     }
 }


### PR DESCRIPTION
**What changes were proposed in this pull request**
Add support for [cardano preview](https://docs.cardano.org/cardano-testnet/getting-started#environments). It also includes an extra example for showing how to switch the network to connect to.