### PR TITLE
Adjust return types for asset and tx endpoints

### DIFF
--- a/src/api/endpoints/assets.rs
+++ b/src/api/endpoints/assets.rs
@@ -52,7 +52,9 @@ impl BlockfrostAPI {
 mod tests {
     use super::*;
     use blockfrost_openapi::models::{
-        asset::Asset, asset_transactions_inner::AssetTransactionsInner,
+        asset::Asset, 
+        asset_transactions_inner::AssetTransactionsInner,
+        assets_inner::AssetsInner,
     };
     use serde_json::json;
 
@@ -73,7 +75,7 @@ mod tests {
             }
         ]);
 
-        serde_json::from_value::<Vec<Asset>>(json_value).unwrap();
+        serde_json::from_value::<Vec<AssetsInner>>(json_value).unwrap();
     }
 
     #[tokio::test]

--- a/src/api/endpoints/assets.rs
+++ b/src/api/endpoints/assets.rs
@@ -3,6 +3,7 @@ use blockfrost_openapi::models::{
     asset_addresses_inner::AssetAddressesInner, asset_history_inner::AssetHistoryInner,
     asset_policy_inner::AssetPolicyInner, asset_transactions_inner::AssetTransactionsInner,
     asset::Asset,
+    assets_inner::AssetsInner,
 };
 
 impl BlockfrostAPI {
@@ -11,7 +12,7 @@ impl BlockfrostAPI {
             .await
     }
 
-    pub async fn assets(&self, pagination: Pagination) -> BlockfrostResult<Vec<Asset>> {
+    pub async fn assets(&self, pagination: Pagination) -> BlockfrostResult<Vec<AssetsInner>> {
         self.call_paged_endpoint("/assets", pagination).await
     }
 

--- a/src/api/endpoints/assets.rs
+++ b/src/api/endpoints/assets.rs
@@ -2,16 +2,16 @@ use crate::*;
 use blockfrost_openapi::models::{
     asset_addresses_inner::AssetAddressesInner, asset_history_inner::AssetHistoryInner,
     asset_policy_inner::AssetPolicyInner, asset_transactions_inner::AssetTransactionsInner,
-    assets_inner::AssetsInner,
+    asset::Asset,
 };
 
 impl BlockfrostAPI {
-    pub async fn assets_by_id(&self, asset: &str) -> BlockfrostResult<AssetsInner> {
+    pub async fn assets_by_id(&self, asset: &str) -> BlockfrostResult<Asset> {
         self.call_endpoint(format!("/assets/{}", asset).as_str())
             .await
     }
 
-    pub async fn assets(&self, pagination: Pagination) -> BlockfrostResult<Vec<AssetsInner>> {
+    pub async fn assets(&self, pagination: Pagination) -> BlockfrostResult<Vec<Asset>> {
         self.call_paged_endpoint("/assets", pagination).await
     }
 
@@ -72,7 +72,7 @@ mod tests {
             }
         ]);
 
-        serde_json::from_value::<Vec<AssetsInner>>(json_value).unwrap();
+        serde_json::from_value::<Vec<Asset>>(json_value).unwrap();
     }
 
     #[tokio::test]

--- a/src/api/endpoints/transactions.rs
+++ b/src/api/endpoints/transactions.rs
@@ -1,6 +1,7 @@
 use crate::{request::send_request, url::Url, *};
 use blockfrost_openapi::models::{
-    address_transactions_content_inner::AddressTransactionsContentInner, tx_content::TxContent,
+    tx_content::TxContent,
+    tx_content_utxo::TxContentUtxo,
     tx_content_delegations_inner::TxContentDelegationsInner,
     tx_content_metadata_cbor_inner::TxContentMetadataCborInner,
     tx_content_metadata_inner::TxContentMetadataInner, tx_content_mirs_inner::TxContentMirsInner,
@@ -44,11 +45,11 @@ impl BlockfrostAPI {
 
     pub async fn transaction_by_hash(
         &self, hash: &str,
-    ) -> BlockfrostResult<AddressTransactionsContentInner> {
+    ) -> BlockfrostResult<TxContent> {
         self.call_endpoint(format!("/txs/{}", hash).as_str()).await
     }
 
-    pub async fn transactions_utxos(&self, hash: &str) -> BlockfrostResult<TxContent> {
+    pub async fn transactions_utxos(&self, hash: &str) -> BlockfrostResult<TxContentUtxo> {
         self.call_endpoint(format!("/txs/{}/utxos", hash).as_str())
             .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use api::*;
 pub use error::*;
 pub use ipfs::BlockfrostIPFS;
 pub use pagination::Pagination;
+pub use pagination::Order;
 pub use settings::*;
 pub use types::*;
 


### PR DESCRIPTION
This pull requests changes the return types for asset and tx endpoints in order to reflect the actual data returned by the blockfrost API.
Additionally, `Order` is exposed to allow customization of pagination order.

Changed types:
- `assets_by_id` from `AssetsInner` to `Asset` to reflect `GET /assets/{asset}`
- `transactions_by_hash` from `AddressTransactionsContentInner` to `TxContent` to reflect `GET /txs/{hash}`
- `transactions_utxos` from `TxContent` to `TxContentUtxo` to reflect `GET /txs/{hash}/utxos`

This also addresses Issue #45 