### PR TITLE
feat: allow callers to pass header values

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,7 +18,7 @@ pub struct BlockfrostAPI {
 
 impl BlockfrostAPI {
     pub fn new(project_id: &str, settings: BlockFrostSettings) -> Self {
-        let client = create_client_with_project_id(project_id);
+        let client = create_client_with_project_id(project_id, &settings.headers);
         let base_url = Url::get_base_url_from_project_id(project_id);
 
         Self {
@@ -34,7 +34,7 @@ impl BlockfrostAPI {
         let base_url = Url::get_base_url_from_project_id(project_id);
 
         client_builder
-            .default_headers(build_header_map(project_id))
+            .default_headers(build_header_map(project_id, &settings.headers))
             .build()
             .map(|client| Self {
                 settings,

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -32,7 +32,7 @@ impl BlockfrostIPFS {
     /// [`HeaderValue`]: reqwest::header::HeaderValue
     /// [`HeaderValue::from_str`]: reqwest::header::HeaderValue::from_str
     pub fn new(project_id: &str, settings: IpfsSettings) -> Self {
-        let client = create_client_with_project_id(project_id);
+        let client = create_client_with_project_id(project_id, &settings.headers);
 
         Self {
             client,
@@ -62,7 +62,7 @@ impl BlockfrostIPFS {
         project_id: impl AsRef<str>, settings: IpfsSettings, client_builder: ClientBuilder,
     ) -> reqwest::Result<Self> {
         client_builder
-            .default_headers(build_header_map(project_id.as_ref()))
+            .default_headers(build_header_map(project_id.as_ref(), &settings.headers))
             .build()
             .map(|client| Self {
                 settings,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,21 +1,26 @@
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct BlockFrostSettings {
     pub retry_settings: RetrySettings,
+    pub headers: HashMap<String, String>,
 }
 
 impl BlockFrostSettings {
     pub fn new() -> Self {
         Self {
             retry_settings: RetrySettings::default(),
+            headers: HashMap::new(),
         }
     }
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct IpfsSettings {
     pub retry_settings: RetrySettings,
+    pub headers: HashMap<String, String>,
 }
 
 impl IpfsSettings {
@@ -29,6 +34,7 @@ impl IpfsSettings {
     pub fn new() -> Self {
         Self {
             retry_settings: RetrySettings::default(),
+            headers: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
Added `headers` to blockfrost settings. Lets you pass arbitrary headers when constructing a `BlockfrostAPI`.

Adding a new field to `BlockfrostSettings` and `IpfsSettings` is technically a breaking change, though I couldn't find any code on GitHub which would be broken by it. Any code which constructed those structs directly (without using `new` or `default()`) would be broken. I added `#{non_exhaustive]` attributes to both of those structs, to ensure nobody can do that in the future.